### PR TITLE
better login setup

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -6,7 +6,8 @@ from django.contrib.auth.decorators import login_required
 
 from .models import Post, Like
 
-# Create your views here.
+# index requires account
+@login_required
 def index(request):
     posts = Post.objects.order_by("-published_date").annotate(num_likes=Count("likes"))
     return render(request, 'home.html', {'posts': posts})

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -9,4 +9,5 @@
   {{ form.as_p }}
   <button type="submit">Log In</button>
 </form>
+<a href='../signup'>no account? sign up</a>
 {% endblock %}

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -8,6 +8,7 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" value="Register">
+    <button type="submit">Register</button>
   </form>
+  <a href='../login'>allready have an account? login</a>
 {% endblock %}


### PR DESCRIPTION
this PR makes it so that users cannot view the home screen without signing up. this is being done for several reasons, 1: later the home screen might be customized, so at some point, this will need to happen. and 2: people inside the instance may not want people outside the instance to read their content. this PR also adds a link to the login screen on the signup screen, and a link to the login on the signup screen.